### PR TITLE
Add 404 page

### DIFF
--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,0 +1,18 @@
+---
+import Layout from "../layouts/Layout.astro";
+import "../styles/globals.css";
+---
+
+<Layout>
+  <section class="bg-gradient-to-br from-slate-900 to-slate-700 text-white min-h-screen flex items-center justify-center">
+    <div class="container mx-auto px-6 sm:px-12 text-center space-y-6">
+      <i class="fas fa-rocket text-6xl text-blue-400 animate-bounce"></i>
+      <h1 class="text-5xl font-bold">¡Ups! Aquí no hay nada...</h1>
+      <p class="text-lg text-gray-300">Parece que aquí no está lo que buscas.</p>
+      <a href="/" class="bg-blue-500 text-white px-6 py-2 rounded-lg hover:bg-blue-600 inline-flex items-center space-x-2">
+        <i class="fas fa-home"></i>
+        <span>Volver al inicio</span>
+      </a>
+    </div>
+  </section>
+</Layout>


### PR DESCRIPTION
## Summary
- add a custom 404 page with a return home link
- tweak the text to better match the site's tone

## Testing
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686569cb81e8832dac4bbaa669342254